### PR TITLE
Fix Joomla CMS PR #26079

### DIFF
--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -169,7 +169,7 @@ class ExtensionAdapter extends UpdateAdapter
 						if ($dbType === 'mysql')
 						{
 							// Check whether we have a MariaDB version string and extract the proper version from it
-							if (stripos($version, 'mariadb') !== false)
+							if (stripos($dbVersion, 'mariadb') !== false)
 							{
 								// MariaDB: Strip off any leading '5.5.5-', if present
 								$dbVersion = preg_replace('/^5\.5\.5-/', '', $dbVersion);

--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -169,9 +169,10 @@ class ExtensionAdapter extends UpdateAdapter
 						if ($dbType === 'mysql')
 						{
 							// Check whether we have a MariaDB version string and extract the proper version from it
-							if (preg_match('/^(?:5\.5\.5-)?(mariadb-)?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)/i', $dbVersion, $versionParts))
+							if (stripos($version, 'mariadb') !== false)
 							{
-								$dbVersion = $versionParts['major'] . '.' . $versionParts['minor'] . '.' . $versionParts['patch'];
+								// MariaDB: Strip off any leading '5.5.5-', if present
+								$dbVersion = preg_replace('/^5\.5\.5-/', '', $dbVersion);
 								$dbType    = 'mariadb';
 							}
 						}

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -380,9 +380,10 @@ class Update extends \JObject
 						if ($dbType === 'mysql')
 						{
 							// Check whether we have a MariaDB version string and extract the proper version from it
-							if (preg_match('/^(?:5\.5\.5-)?(mariadb-)?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)/i', $dbVersion, $versionParts))
+							if (stripos($version, 'mariadb') !== false)
 							{
-								$dbVersion = $versionParts['major'] . '.' . $versionParts['minor'] . '.' . $versionParts['patch'];
+								// MariaDB: Strip off any leading '5.5.5-', if present
+								$dbVersion = preg_replace('/^5\.5\.5-/', '', $dbVersion);
 								$dbType    = 'mariadb';
 							}
 						}

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -380,7 +380,7 @@ class Update extends \JObject
 						if ($dbType === 'mysql')
 						{
 							// Check whether we have a MariaDB version string and extract the proper version from it
-							if (stripos($version, 'mariadb') !== false)
+							if (stripos($dbVersion, 'mariadb') !== false)
 							{
 								// MariaDB: Strip off any leading '5.5.5-', if present
 								$dbVersion = preg_replace('/^5\.5\.5-/', '', $dbVersion);


### PR DESCRIPTION
Pull Request for [https://github.com/joomla/joomla-cms/pull/26079](https://github.com/joomla/joomla-cms/pull/26079).

### Summary of Changes

The regex to check for MariaDB is good for extracting the version number when having a MariaDB, but it is not good for checking if the DB is a MariaDB or not, because the "(mariadb-)?" part of the regex may appear zero ore one time.

It is safer to check if the version string contains mariadb (case insensitive), becaue it may appear at the beginning or at the end. The regex des not cover this.

This PR here changes it so it works the same way as in the db driver from framework 2.0-dev branch, and there it was implemented by me.

### Testing Instructions

Paste the regex into an online tool and check if it matches also to a **MySQL** version string.

### Expected result

Should not match.

### Actual result

Matches.

### Documentation Changes Required

None.