### PR TITLE
Fix Joomla CMS PR #26104

### DIFF
--- a/administrator/components/com_admin/postinstall/joomla40checks.php
+++ b/administrator/components/com_admin/postinstall/joomla40checks.php
@@ -41,13 +41,12 @@ function admin_postinstall_joomla40checks_condition()
 	}
 
 	// Check whether we have a MariaDB version string and extract the proper version from it
-	if ($serverType == 'mysql'
-		&& preg_match('/^(?:5\.5\.5-)?(mariadb-)?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)/i', $serverVersion, $versionParts))
+	if ($serverType == 'mysql' && stripos($serverVersion, 'mariadb') !== false)
 	{
-		$dbVersion = $versionParts['major'] . '.' . $versionParts['minor'] . '.' . $versionParts['patch'];
+		$serverVersion = preg_replace('/^5\.5\.5-/', '', $serverVersion);
 
 		// MariaDB minimum version is 10.1
-		if (version_compare($dbVersion, '10.1', 'lt'))
+		if (version_compare($serverVersion, '10.1', 'lt'))
 		{
 			return true;
 		}


### PR DESCRIPTION
Pull Request for [https://github.com/joomla/joomla-cms/pull/26104](https://github.com/joomla/joomla-cms/pull/26104).

### Summary of Changes

The regex to check for MariaDB is good for extracting the version number when having a MariaDB, but it is not good for checking if the DB is a MariaDB or not, because the "(mariadb-)?" part of the regex may appear zero ore one time.

It is safer to check if the version string contains mariadb (case insensitive), becaue it may appear at the beginning or at the end. The regex des not cover this.

This PR here changes it so it works the same way as in the db driver from framework 2.0-dev branch, and there it was implemented by me.

### Testing Instructions

Paste the regex into an online tool and check if it matches also to a **MySQL** version string.

### Expected result

Should not match.

### Actual result

Matches.

### Documentation Changes Required

None.