### PR TITLE
[joomla-cms] [PR 30748] Add update SQL scripts 4.0.0-2020-09-27.sql

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-09-27.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2020-09-27.sql
@@ -1,0 +1,1 @@
+DELETE FROM `#__extensions` WHERE `name` = 'plg_content_imagelazyload' AND `type` = 'plugin' AND `element` = 'imagelazyload' AND `folder` = 'content' AND `client_id` = 0;

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-09-27.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2020-09-27.sql
@@ -1,0 +1,1 @@
+DELETE FROM "#__extensions" WHERE "name" = 'plg_content_imagelazyload' AND "type" = 'plugin' AND "element" = 'imagelazyload' AND "folder" = 'content' AND "client_id" = 0;


### PR DESCRIPTION
Pull Request for [https://github.com/joomla/joomla-cms/pull/30748](https://github.com/joomla/joomla-cms/pull/30748).

### Summary of Changes

Add new update SQL script to delete the plugin from the extensions table.

### Testing Instructions

Important: The testing instructions of PR [https://github.com/joomla/joomla-cms/pull/30748](https://github.com/joomla/joomla-cms/pull/30748) should be extended by this test here.

1. On a clean 4.0-dev or 4.0 Beta 4 or latest 4.0 nightly installation, update to the update package built by Drone for this PR. The link "Details" can be find at the bottom of the PR in the test section for the test "Package" at the right hand side. There you can find an update package and a custom update URL.

2. Verify that the update suceeds without SQL errors.

3. Check in the list of plugins in backend that the plugin can't be found anymore.

### Actual result BEFORE applying this Pull Request

Plugin still in the list after update.

### Expected result AFTER applying this Pull Request

Plugin not in the list anymore.

### Documentation Changes Required

No.